### PR TITLE
Created help output and option specific help

### DIFF
--- a/cliCommand.sh
+++ b/cliCommand.sh
@@ -52,7 +52,7 @@ while true; do
 	jsonfile="["
 	shift;
 	[[ ! -r $1 ]] && {
-		echo "Incorrect Usage: cliCommand.sh -j [FILE]" 
+		echo "Incorrect Usage: cliCommand.sh -j|--json [FILE]" 
 		exit 1
 	}
 	break

--- a/cliCommand.sh
+++ b/cliCommand.sh
@@ -9,21 +9,72 @@ CLICOLOR=1
 exitCode=0
 json=0
 
+#### Help
+Help()
+{
+	echo
+	echo "Usage: cliCommand.sh [OPTION]... [FILE]"
+	echo "Command-line tool to consider if urls are good, bad, or unknown."
+	echo
+	echo "  -v, --version    Print cliCommand version"
+	echo "  -j, --json       Output results to urls.json file"
+	echo "  -h, --help       Print this help message"
+	echo
+}
+
+
+# Call getopt to validate the provided input. 
+options=$(getopt -o vj:h --long version,json:,help -- "$@" 2> /dev/null)
+[ $? -eq 0 ] || { 
+    case "$1" in 
+    # Output if json option is used incorrectly
+    -j | --json )
+        echo "Incorrect Usage: cliCommand.sh -j|--json [FILE]"
+	exit 1
+	;;
+    *)
+    	echo "Incorrect options provided"
+    	Help
+    	exit 1
+	;;
+    esac
+}
+eval set -- "$options"
+while true; do
+    case "$1" in
+    # If the user wants to know the version
+    -v | --version )
+        source get_version.sh
+	exit 0
+        ;;
+    # If the user wants a json output
+    -j | --json )
+	jsonfile="["
+	shift;
+	[[ ! -r $1 ]] && {
+		echo "Incorrect Usage: cliCommand.sh -j [FILE]" 
+		exit 1
+	}
+	break
+        ;;
+    -h | --help )
+	Help
+	exit 0
+	;;
+    --)
+        shift
+        break
+        ;;
+    esac
+    shift
+done
+
 # if the user forgot to include arguements.
-if [ $# -eq 0 ]
-  then
+[[ $# -eq 0 ]] && {
 	source get_instructions.sh
-	exit
-fi
+	exit 1
+}
 
-# If the user wants to know the version
-source get_version.sh $1
-
-# If the user wants a json output
-if [ $json -eq 0 ]
-	then
-		jsonfile="["
-fi
 
 # Parsing file and looking for all URLS.
 for i in $(grep -Eo '(http|https)://[^/"]+' $1)

--- a/get_instructions.sh
+++ b/get_instructions.sh
@@ -1,2 +1,1 @@
-printf "Please enter the html file\n"
-printf "Ex. ./cliCommand <theFile.txt>\n"
+Help

--- a/get_version.sh
+++ b/get_version.sh
@@ -1,4 +1,4 @@
-if [ $1 = "-v" ]
+if [ $1 = "-v" ] || [ $1 = "--version" ]
 	then
 	printf "v0.2\n"
 	exit


### PR DESCRIPTION
Created help output as well as arg specific help for -j option. Examples:
```
→ ./cliCommand.sh --help

Usage: cliCommand.sh [OPTION]... [FILE]
Command-line tool to consider if urls are good, bad, or unknown.

  -v, --version    Print cliCommand version
  -j, --json       Output results to urls.json file
  -h, --help       Print this help message
```
```
→ ./cliCommand.sh -j
Incorrect Usage: cliCommand.sh -j|--json [FILE]
```
```
→ ./cliCommand.sh -j nonexistentfile.txt
Incorrect Usage: cliCommand.sh -j|--json [FILE]
```
```
→ ./cliCommand.sh -j testing.txt
https://wiki.cdot.senecacollege.ca : 301 Unknown
http://zenit.senecac.on.ca :  Unknown
...
```
```
→ ./cliCommand.sh --version
v0.2
```
```
→ ./cliCommand.sh -c
Incorrect options provided

Usage: cliCommand.sh [OPTION]... [FILE]
Command-line tool to consider if urls are good, bad, or unknown.

  -v, --version    Print cliCommand version
  -j, --json       Output results to urls.json file
  -h, --help       Print this help message
```
------------
* Moved your jsonfile variable assignment into my case block whenever the -j option is used
* Modified get_instructions.sh to return my Help function - We could remove this file and return Help directly in the script
* Modified get_version.sh to allow --version option

**Please let me know what you think. Thanks!**